### PR TITLE
Don't force cppcheck to run all configurations

### DIFF
--- a/runchecks.sh
+++ b/runchecks.sh
@@ -22,4 +22,4 @@ for file in "${ignore_files[@]}"; do
   cppcheck_ignores+=(-i "*/$file/*")
 done
 
-cppcheck --enable=all --force --std=c++11 --language=c++ --project=$INPUT_BUILD_PATH/compile_commands.json "${cppcheck_ignores[@]}" --output-file=$GITHUB_WORKSPACE/cppcheck-report.txt
+cppcheck --enable=all --std=c++17 --language=c++ --project=$INPUT_BUILD_PATH/compile_commands.json "${cppcheck_ignores[@]}" --output-file=$GITHUB_WORKSPACE/cppcheck-report.txt


### PR DESCRIPTION
cppcheck tries to check all possible combinations of preprocessor directives, based on the included files. By default, it will only do this if it finds 12 or less, unless `--force` is passed.
This takes a really long time, since it's testing a lot of useless variables: every AMReX feature we're not using, every possible GPU setup (plus a bunch that aren't possible), and a bunch of compiler checks and feature tests all over the codebase.